### PR TITLE
revert to older electron-prebuilt

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "decibels": "^1.0.0",
     "deep-equal": "^0.2.1",
     "dom-delegator": "~13.1.0",
-    "electron-prebuilt": "~0.30.1",
+    "electron-prebuilt": "~0.27.3",
     "frac": "^0.3.1",
     "geval": "^2.1.1",
     "hyperscript": "^1.4.6",


### PR DESCRIPTION
electron-prebuilt v0.30.1 was glitching a lot, going back to v0.27.3 fixed it