### PR TITLE
Added "Linux" to the "Troubleshooting" area

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,21 @@ $ npm install
 $ npm start
 ```
 
-### When running on Windows
+### Troubleshooting
 
 If you receive an error on start up about missing `lib/*`, you may have to [run the following as administrator](http://www.howtogeek.com/howto/windows-vista/run-a-command-as-administrator-from-the-windows-vista-run-box/):
+
+#### Windows
 
 ```bash
 # run admin
 $ node scripts/link-lib.js
+```
+
+#### Linux
+
+```bash
+$ sudo node scripts/link-lib.js
 ```
 
 If it still doesn't work, try copying the `/lib` folder into `/node_modules`.


### PR DESCRIPTION
I tried to build your awesome project from source on Linux (Ubuntu) and I got the following error:

```
Error opening app
The app provided is not a valid Electron app, please read the docs on how to write one:
https://github.com/atom/electron/tree/v0.36.6/docs

Error: Cannot find module 'lib/menu'
```

I tried to debug the code and found the problem. Then I got back to your repo and saw the `When running on Windows` part of the README. I totally missed that the first time because I'm not using Windows and I don't read stuff that has a Windows focus.

That's why I added a "troubleshooting" area to the README to have a section for Windows and one for Linux. 